### PR TITLE
sbcl 2.0.5からのfile-positionの挙動が変わったのでそれに対応する修正

### DIFF
--- a/lisp-preprocessor.lisp
+++ b/lisp-preprocessor.lisp
@@ -76,7 +76,8 @@
           :for pos := (search *template-begin* text :start2 start)
           :while pos
           :do (unless (= start pos) (push (list :string (subseq text start pos)) forms))
-              (with-input-from-string (in text :start (begin+ pos))
+              (with-input-from-string (in text)
+                (file-position in (begin+ pos))
                 (multiple-value-bind (template-form next fresh-line-p)
                     (read-template-form in text (compute-column text pos))
                   (setq end next)


### PR DESCRIPTION
```
(with-input-from-string (in "abc" :start 1)
  (file-position in))
```
の返り値がsbcl 2.0.4以前はstartと同じ値だったが2.0.5以降は0になった
代わりにwith-input-from-stringの先頭で`(file-position stream start)`とすることで対応